### PR TITLE
TST: Enable tests for python 3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,12 @@ jobs:
       env:
         CONDA_PREFIX: /usr/share/miniconda
 
+    - name: Conda info
+      run: conda info
+
+    - name: Conda list
+      run: conda list -n base
+
     - name: Test with pytest
       env:
         CONDA_PREFIX: /usr/share/miniconda

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
     - name: install conda dependencies
       env:
         TORCH: "1.8"
-      run: conda install h5py scipy rdkit pytorch==${TORCH} torchvision cpuonly dgl -c pytorch -c conda-forge -c dglteam
+      run: conda install scipy rdkit pytorch==${TORCH} torchvision cpuonly dgl -c pytorch -c conda-forge -c dglteam
 
     - name: install torch-geometric dependencies
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.4.0
+      uses: styfle/cancel-workflow-action@0.9.1
       with:
           access_token: ${{ github.token }}
     - uses: actions/checkout@v2
@@ -56,7 +56,7 @@ jobs:
         pytest
 
     - name: coverage
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       with:
         file: ./coverage.xml
         name: codecov-umbrella

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: build with conda
 on: [push]
 
 env:
-  TORCH: "1.8.1"
+  TORCH: "1.8.0"
 
 jobs:
   build:
@@ -27,8 +27,7 @@ jobs:
         update-conda: true
         python-version: ${{ matrix.version }}
         conda-channels: anaconda
-    - run: conda --version
-    - run: which python
+
     - name: install conda dependencies
 
       run: conda install scipy rdkit pytorch==${TORCH} torchvision cpuonly dgl -c pytorch -c conda-forge -c dglteam

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
       run: |
         # torch==1.8.1 dependencies
         conda install scipy rdkit pytorch==${TORCH} torchvision cpuonly dgl -c pytorch -c conda-forge -c dglteam
+        pip install "gpytorch<=1.5.1"  # TODO: Remove when switching to pytorch >=1.9
 
         # torch-geometric dependencies
         pip install --no-index torch-scatter -f https://pytorch-geometric.com/whl/torch-${TORCH}+cpu.html

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,8 @@ name: build with conda
 on: [push]
 
 env:
-  TORCH: "1.8.0"
+  TORCH: "1.8.1"
+  CONDA_PREFIX: /usr/share/miniconda
 
 jobs:
   build:
@@ -28,25 +29,19 @@ jobs:
         python-version: ${{ matrix.version }}
         conda-channels: anaconda
 
-    - name: install conda dependencies
-
-      run: conda install scipy rdkit pytorch==${TORCH} torchvision cpuonly dgl -c pytorch -c conda-forge -c dglteam
-
-    - name: install torch-geometric dependencies
+    - name: install dependencies
       run: |
+        # torch==1.8.1 dependencies
+        conda install scipy rdkit pytorch==${TORCH} torchvision cpuonly dgl -c pytorch -c conda-forge -c dglteam
+
+        # torch-geometric dependencies
         pip install --no-index torch-scatter -f https://pytorch-geometric.com/whl/torch-${TORCH}+cpu.html
         pip install --no-index torch-sparse -f https://pytorch-geometric.com/whl/torch-${TORCH}+cpu.html
         pip install --no-index torch-cluster -f https://pytorch-geometric.com/whl/torch-${TORCH}+cpu.html
         pip install --no-index torch-spline-conv -f https://pytorch-geometric.com/whl/torch-${TORCH}+cpu.html
-        pip install torch-geometric
 
-    - name: install torch-geometric
-      run:  pip install torch-geometric
-
-    - name: Install the package
-      run: pip install .[test,doc]
-      env:
-        CONDA_PREFIX: /usr/share/miniconda
+        # The package
+        pip install .[test,doc]
 
     - name: Conda info
       run: conda info
@@ -55,8 +50,6 @@ jobs:
       run: conda list -n base
 
     - name: Test with pytest
-      env:
-        CONDA_PREFIX: /usr/share/miniconda
       run: |
         pytest
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@ name: build with conda
 
 on: [push]
 
+env:
+  TORCH: "1.8.1"
+
 jobs:
   build:
 
@@ -27,18 +30,15 @@ jobs:
     - run: conda --version
     - run: which python
     - name: install conda dependencies
-      env:
-        TORCH: "1.8"
+
       run: conda install scipy rdkit pytorch==${TORCH} torchvision cpuonly dgl -c pytorch -c conda-forge -c dglteam
 
     - name: install torch-geometric dependencies
-      env:
-        TORCHG: "1.8.0"
       run: |
-        pip install --no-index torch-scatter -f https://pytorch-geometric.com/whl/torch-${TORCHG}+cpu.html
-        pip install --no-index torch-sparse -f https://pytorch-geometric.com/whl/torch-${TORCHG}+cpu.html
-        pip install --no-index torch-cluster -f https://pytorch-geometric.com/whl/torch-${TORCHG}+cpu.html
-        pip install --no-index torch-spline-conv -f https://pytorch-geometric.com/whl/torch-${TORCHG}+cpu.html
+        pip install --no-index torch-scatter -f https://pytorch-geometric.com/whl/torch-${TORCH}+cpu.html
+        pip install --no-index torch-sparse -f https://pytorch-geometric.com/whl/torch-${TORCH}+cpu.html
+        pip install --no-index torch-cluster -f https://pytorch-geometric.com/whl/torch-${TORCH}+cpu.html
+        pip install --no-index torch-spline-conv -f https://pytorch-geometric.com/whl/torch-${TORCH}+cpu.html
         pip install torch-geometric
 
     - name: install torch-geometric

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [3.7, 3.8]
+        version: [3.7, 3.8, 3.9]
 
     steps:
     - name: Cancel Previous Runs

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     install_requires=[
         'e3nn@git+https://github.com/e3nn/e3nn@main',

--- a/swan/dataset/splitter.py
+++ b/swan/dataset/splitter.py
@@ -1,4 +1,6 @@
-from typing import Generic, NamedTuple, Tuple, TypeVar, Union
+from __future__ import annotations
+
+from typing import NamedTuple, Tuple, TypeVar
 
 import numpy as np
 import torch
@@ -6,19 +8,21 @@ import torch
 from ..state import StateH5
 from ..type_hints import PathLike
 
-T_co = TypeVar('T_co', bound=Union[np.ndarray, torch.Tensor], covariant=True)
 
-
-class SplitDataset(NamedTuple, Generic[T_co]):
+class SplitDataset(NamedTuple):
     indices: np.ndarray       # Shuffled indices to split the data
     ntrain: int               # Number of points used for training
-    features_trainset: T_co   # Features for training
-    features_validset: T_co   # Features for validation
-    labels_trainset: T_co     # Labels for training
-    labels_validset: T_co     # Labels for validation
+    features_trainset: np.ndarray | torch.Tensor   # Features for training
+    features_validset: np.ndarray | torch.Tensor   # Features for validation
+    labels_trainset: np.ndarray | torch.Tensor     # Labels for training
+    labels_validset: np.ndarray | torch.Tensor     # Labels for validation
 
 
-def split_dataset(features: T_co, labels: T_co, frac: Tuple[float, float] = (0.8, 0.2)) -> SplitDataset:
+def split_dataset(
+    features: np.ndarray | torch.Tensor,
+    labels: np.ndarray | torch.Tensor,
+    frac: Tuple[float, float] = (0.8, 0.2),
+) -> SplitDataset:
     """Split the fingerprint dataset into a training and validation set.
 
     Parameters


### PR DESCRIPTION
Previously only Python 3.7 and 3.8 were tested in the CI; this PR also adds 3.9.

On a secondary note, it seems pytorch has had a 1.9 and 1.10 release some time ago. 
Would it be worthwhile to bump the pinned version?